### PR TITLE
Ciphers

### DIFF
--- a/meinstall.ui
+++ b/meinstall.ui
@@ -1319,7 +1319,7 @@
             </property>
            </widget>
           </item>
-          <item row="20" column="1">
+          <item row="22" column="1">
            <widget class="QSpinBox" name="spinFDEroundtime">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -1376,7 +1376,7 @@
             </property>
            </widget>
           </item>
-          <item row="22" column="0">
+          <item row="25" column="0">
            <spacer name="verticalSpacer_6">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -1389,7 +1389,7 @@
             </property>
            </spacer>
           </item>
-          <item row="20" column="0">
+          <item row="22" column="0">
            <widget class="QLabel" name="labelFDEroundtime">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -1469,7 +1469,7 @@
             </item>
            </widget>
           </item>
-          <item row="21" column="1">
+          <item row="24" column="1">
            <widget class="QPushButton" name="buttonBenchmarkFDE">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -1574,6 +1574,27 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="21" column="0">
+           <widget class="QLabel" name="labelFDErandom">
+            <property name="text">
+             <string>Kernel RNG:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="21" column="1">
+           <widget class="QComboBox" name="comboFDErandom">
+            <item>
+             <property name="text">
+              <string>random</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>urandom</string>
+             </property>
+            </item>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -639,8 +639,9 @@ void MInstall::loadAdvancedFDE()
     if(indexFDEivgen >= 0) comboFDEivgen->setCurrentIndex(indexFDEivgen);
     on_comboFDEivgen_currentIndexChanged(comboFDEivgen->currentText());
     if(indexFDEivhash >= 0) comboFDEivhash->setCurrentIndex(indexFDEivhash);
-    if(iFDEkeysize > 0) spinFDEkeysize->setValue(iFDEkeysize);
+    if(iFDEkeysize >= 0) spinFDEkeysize->setValue(iFDEkeysize);
     if(indexFDEhash >= 0) comboFDEhash->setCurrentIndex(indexFDEhash);
+    if(indexFDErandom >= 0) comboFDErandom->setCurrentIndex(indexFDErandom);
     if(iFDEroundtime >= 0) spinFDEroundtime->setValue(iFDEroundtime);
 }
 
@@ -652,6 +653,7 @@ void MInstall::saveAdvancedFDE()
     indexFDEivhash = comboFDEivhash->currentIndex();
     iFDEkeysize = spinFDEkeysize->value();
     indexFDEhash = comboFDEhash->currentIndex();
+    indexFDErandom = comboFDErandom->currentIndex();
     iFDEroundtime = spinFDEroundtime->value();
 }
 
@@ -808,6 +810,7 @@ bool MInstall::makeLuksPartition(const QString &dev, const QString &fs_name, con
                " --cipher " + strCipherSpec.toLower()
                + " --key-size " + spinFDEkeysize->cleanText()
                + " --hash " + comboFDEhash->currentText().toLower().remove('-')
+               + " --use-" + comboFDErandom->currentText()
                + " --iter-time " + spinFDEroundtime->cleanText()
                + " luksFormat " + dev);
     proc.waitForStarted();
@@ -2590,12 +2593,16 @@ void MInstall::pageDisplayed(int next)
                                        "ECB mode does not use an IV, so these fields will all be disabled if ECB is selected for the chain mode."
                                        "</p>"
                                        "<p>"
-                                       "<b>Key size</b><br/>Sets the key size in bits. Available key sizes are limited by the cipher and chain mode.<br />"
+                                       "<b>Key size</b><br/>Sets the key size in bits. Available key sizes are limited by the cipher and chain mode.<br/>"
                                        "The XTS cipher chain mode splits the key in half (for example, AES-256 in XTS mode requires a 512-bit key size)."
                                        "</p>"
                                        "<p>"
                                        "<b>LUKS key hash</b><br/>The hash used for PBKDF2 and for the AF splitter.<br/>"
                                        "SHA-1 and RIPEMD-160 are no longer recommended for sensitive applications as they have been found to be broken."
+                                       "</p>"
+                                       "<p>"
+                                       "<b>Kernel RNG</b><br/>Sets which kernel random number generator will be used to create the master key volume key (which is a long-term key).<br/>"
+                                       "Two options are available: /dev/<b>random</b> which blocks until sufficient entropy is obtained (can take a long time in low-entropy situations), and /dev/<b>urandom</b> which will not block even if there is insufficient entropy (possibly weaker keys)."
                                        "</p>"
                                        "<p>"
                                        "<b>KDF round time</b><br/>The amount of time (in milliseconds) to spend with PBKDF2 passphrase processing.<br/>"

--- a/minstall.h
+++ b/minstall.h
@@ -223,5 +223,6 @@ private:
     int indexFDEivhash = -1;
     int iFDEkeysize = -1;
     int indexFDEhash = -1;
+    int indexFDErandom = -1;
     long iFDEroundtime = -1;
 };


### PR DESCRIPTION
Added an option to select which kernel RNG to use (use /dev/random by default to prevent weak keys being used if insufficient entropy is present).