### PR TITLE
Compact progress bar layout

### DIFF
--- a/meinstall.ui
+++ b/meinstall.ui
@@ -156,7 +156,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>6</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="Step_Terms">
       <layout class="QGridLayout" name="_4">
@@ -1696,20 +1696,20 @@
           <property name="spacing">
            <number>6</number>
           </property>
-          <item row="2" column="0">
-           <spacer>
+          <item row="0" column="0">
+           <widget class="QProgressBar" name="progressBar">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
+           </widget>
           </item>
-          <item row="2" column="1">
+          <item row="0" column="2">
            <widget class="QPushButton" name="abortInstallButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
@@ -1725,51 +1725,6 @@
             </property>
             <property name="shortcut">
              <string>Alt+A</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <spacer>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="0" colspan="3">
-           <widget class="QProgressBar" name="progressBar">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" colspan="3">
-           <widget class="QLabel" name="installLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Ready to install antiX Linux filesystem</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
             </property>
            </widget>
           </item>

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -320,7 +320,7 @@ bool MInstall::replaceStringInFile(QString oldtext, QString newtext, QString fil
 
 void MInstall::updateStatus(QString msg, int val)
 {
-    installLabel->setText(msg.toUtf8());
+    progressBar->setFormat("%p% - " + msg.toUtf8());
     progressBar->setValue(val);
     qApp->processEvents();
 }


### PR DESCRIPTION
The progress bar's vertical layout is compacted by:

1. Displaying the status inside the progress bar itself rather than a separate label. The progress bar has more than enough room for the status message and the percentage, even on a small 800x600 screen.

2. Moving the "Abort" button to the end of the bar.

This leaves more room for the "Tips" box.