### PR TITLE
Improve the accuracy of the progress bar by relying on inodes instead of blocks

### DIFF
--- a/minstall.cpp
+++ b/minstall.cpp
@@ -3010,7 +3010,15 @@ void MInstall::procTime()
 
 void MInstall::copyStart()
 {
+    qApp->processEvents();
+    QStringList vlist = getCmdOuts("df --output=iused /dev/loop0 /mnt/antiX");
+    if(vlist.count() >= 3) {
+        iNodesSrc = vlist.at(1).toLong();
+        iNodesDst = vlist.at(2).toLong();
+    }
+    iNodesSrc /= 80;
     timer->start(2000);
+    qApp->processEvents();
     updateStatus(tr("Copying new system"), 15);
 }
 
@@ -3054,19 +3062,12 @@ void MInstall::copyDone(int, QProcess::ExitStatus exitStatus)
 
 void MInstall::copyTime()
 {
-    QString rootdev = "/dev/" + rootCombo->currentText().section(" ", 0, 0);
-    if (isRootEncrypted) {
-        rootdev = "/dev/mapper/rootfs";
+    qApp->processEvents();
+    QStringList vlist = getCmdOuts("df --output=iused /mnt/antiX");
+    long i = 0;
+    if(vlist.count() >= 2) {
+        i = (vlist.at(1).toLong() - iNodesDst) / iNodesSrc;
     }
-
-    QString val = getCmdValue("df /mnt/antiX", rootdev, " ", "/");
-    QRegExp sep("\\s+");
-    QString s = val.section(sep, 2, 2);
-    int i = s.toInt();
-    val = getCmdValue("df /dev/loop0", "/dev/loop0", " ", "/");
-    s = val.section(sep, 2, 2);
-    int j = s.toInt()/27;
-    i = i/j;
     if (i > 79) {
         i = 80;
     }

--- a/minstall.h
+++ b/minstall.h
@@ -206,6 +206,10 @@ private:
     QString home_mntops = "defaults";
     QString root_mntops = "defaults";
 
+    // file copy progress variables
+    long iNodesSrc = 1;
+    long iNodesDst = 1;
+
     // for partition combo updates
     QHash<QString, int> removedRoot; // remember items removed from combo box: item, index
     QHash<QString, int> removedHome;


### PR DESCRIPTION
It is hard to rely on blocks because of the unknown SquashFS compression ratio.
The inode count is more or less identical, at both the source and destination.

Previously the progress bar would move along at a consistent rate and then get stuck at 95% for a few minutes depending on the speed of the system. It also didn't take pre-existing files (eg. /home) into account.