### PR TITLE
Some more fixes

### DIFF
--- a/minstall.cpp
+++ b/minstall.cpp
@@ -1519,7 +1519,7 @@ void MInstall::makeFstab()
             const QString espdev = "/dev/" + grubBootCombo->currentText().section(" ", 0, 0).trimmed();
             const QString espdevUUID = "UUID=" + getCmdOut(cmdBlkID + espdev);
             qDebug() << "espdev" << espdev << espdevUUID;
-            out << espdevUUID + " /boot/efi vfat defaults,noauto,noatime,sync,dmask=0002,fmask=0113 0 0\n";
+            out << espdevUUID + " /boot/efi vfat defaults,noatime,dmask=0002,fmask=0113 0 0\n";
         }
         if (!homedev.isEmpty() && homedev != rootDevicePreserve) {
             fstype = getPartType(homedev);

--- a/minstall.h
+++ b/minstall.h
@@ -64,7 +64,6 @@ public:
     QString getCmdOut(const QString &cmd);
     QStringList getCmdOuts(const QString &cmd);
     static int command(const QString &string);
-    int getPartitionNumber();
 
     bool isInsideVB();
     bool isGpt(const QString &drv);


### PR DESCRIPTION
Rather than counting every single partition just to determine if there are is at least one partition, just stop at the first partition detected.

Also removed the noauto and sync flags from /boot/efi mount point (fehlix reports that it's on debian by default).