### PR TITLE
User interface fixes.

### DIFF
--- a/minstall.cpp
+++ b/minstall.cpp
@@ -2571,16 +2571,20 @@ void MInstall::gotoPage(int next)
     }
 
     int c = widgetStack->count();
+    QSize isize = nextButton->iconSize();
+    isize.setWidth(isize.height());
     if (next >= c-1) {
         // entering the last page
         backButton->hide();
         nextButton->setText(tr("Finish"));
     } else if (next == 3 || next == 6){
         // Advanced Encryption Settings and Services pages
+        isize.setWidth(0);
         nextButton->setText(tr("OK"));
     } else {
         nextButton->setText(tr("Next"));
     }
+    nextButton->setIconSize(isize);
     if (next > c-1) {
         // finished
         updateCursor(Qt::WaitCursor);

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -2141,7 +2141,8 @@ bool MInstall::setComputerName()
         shell.run("mv -f /mnt/antiX/etc/rc2.d/S*nmbd /mnt/antiX/etc/rc2.d/K01nmbd >/dev/null 2>&1");
     }
 
-    if (system("readlink /mnt/antiX/sbin/init") == 0) { // systemd check
+    char rbuf[4];
+    if (readlink("/mnt/antiX/sbin/init", rbuf, sizeof(rbuf)) >= 0) { // systemd check
         if (!sambaCheckBox->isChecked()) {
             runCmd("chroot /mnt/antiX systemctl disable smbd");
             runCmd("chroot /mnt/antiX systemctl disable nmbd");
@@ -2233,7 +2234,8 @@ void MInstall::setServices()
     if (phase < 0) return;
 
     // systemd check
-    bool systemd = (system("readlink /mnt/antiX/sbin/init") == 0);
+    char rbuf[4];
+    bool systemd = (readlink("/mnt/antiX/sbin/init", rbuf, sizeof(rbuf)) >= 0);
 
     QTreeWidgetItemIterator it(csView);
     while (*it) {

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -2228,6 +2228,17 @@ void MInstall::setLocale()
     runCmd("chroot /mnt/antiX localize-repo default");
 }
 
+void MInstall::stashServices(bool save)
+{
+    QTreeWidgetItemIterator it(csView);
+    while (*it) {
+        if ((*it)->parent() != NULL) {
+            (*it)->setCheckState(save?2:0, (*it)->checkState(save?0:2));
+        }
+        ++it;
+    }
+}
+
 void MInstall::setServices()
 {
     qDebug() << "+++" << __PRETTY_FUNCTION__ << "+++";
@@ -2345,9 +2356,8 @@ int MInstall::showPage(int curr, int next)
             haveSysConfig = true;
             next = 4; // Continue
         }
-    } else if (next == 7 && curr == 6) { // at Step_Services (forward)
-        return 8; // goes back to the screen that called Services screen
-    } else if (next == 5 && curr == 6) { // at Step_Services (backward)
+    } else if (curr == 6) { // at Step_Services
+        stashServices(next == 7);
         return 8; // goes back to the screen that called Services screen
     }
     return next;
@@ -2718,6 +2728,7 @@ void MInstall::buildServiceList()
     csView->expandAll();
     csView->resizeColumnToContents(0);
     csView->resizeColumnToContents(1);
+    stashServices(true);
 }
 
 /////////////////////////////////////////////////////////////////////////

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -2564,7 +2564,6 @@ void MInstall::gotoPage(int next)
     // modify ui for standard cases
     if (next == 0) {
         // entering first page
-        nextButton->setText(tr("Next"));
         backButton->hide();
     } else {
         // default
@@ -2576,6 +2575,9 @@ void MInstall::gotoPage(int next)
         // entering the last page
         backButton->hide();
         nextButton->setText(tr("Finish"));
+    } else if (next == 3 || next == 6){
+        // Advanced Encryption Settings and Services pages
+        nextButton->setText(tr("OK"));
     } else {
         nextButton->setText(tr("Next"));
     }

--- a/minstall.h
+++ b/minstall.h
@@ -259,4 +259,5 @@ private:
     bool makeChosenPartitions(QString &rootType, QString &homeType, bool &formatBoot);
     bool formatPartitions(const QByteArray &encPass, const QString &rootType, const QString &homeType, bool formatBoot);
     void failUI(const QString &msg);
+    void stashServices(bool save);
 };


### PR DESCRIPTION
Using system() can compromise the UI responsiveness if the spawn takes too long.

Also changed the text of the Next button to "OK" and hide the arrow when at the Advanced Encryption Settings and Services pages, so the user doesn't end up confused when in these pages.

This should not affect any translations since the "OK" string has already existed for a long time and has been translated.