### PR TITLE
Locale fixes

### DIFF
--- a/minstall.cpp
+++ b/minstall.cpp
@@ -535,6 +535,11 @@ void MInstall::prepareToInstall()
         localeCombo->setCurrentIndex(localeCombo->findData(QVariant("en_GB.UTF-8")));
     }
 
+    // clock 24/12 default
+    if (locale == "en_US.UTF-8" || locale == "ar_EG.UTF-8" || locale == "el_GR.UTF-8" || locale == "sq_AL.UTF-8") {
+        radio12h->setChecked(true);
+    }
+
     // Detect snapshot-backup account(s)
     // test if there's another user than demo in /home, if exists, copy the /home and skip to next step, also skip account setup if demo is present on squashfs
     if (shell.run("ls /home | grep -v lost+found | grep -v demo | grep -v snapshot | grep -q [a-zA-Z0-9]") == 0 || shell.run("test -d /live/linux/home/demo") == 0) {

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -510,17 +510,13 @@ void MInstall::prepareToInstall()
 
     // locale
     localeCombo->clear();
-    file.setFileName("/usr/share/antiX/locales.template");
-    if (file.open(QFile::ReadOnly | QFile::Text)) {
-        while (!file.atEnd()) {
-            const QString line(file.readLine().trimmed());
-            if(!line.startsWith('#')) {
-                QLocale loc(line);
-                localeCombo->addItem(loc.nativeCountryName() + " - " + loc.nativeLanguageName(), QVariant(line));
-            }
-        }
-        file.close();
+    QStringList loclist = getCmdOuts("locale -a | grep -Ev '^(C|POSIX)\\.?' | grep -E 'utf8|UTF-8'");
+    for (QString &strloc : loclist) {
+        strloc.replace("utf8", "UTF-8", Qt::CaseInsensitive);
+        QLocale loc(strloc);
+        localeCombo->addItem(loc.nativeCountryName() + " - " + loc.nativeLanguageName(), QVariant(strloc));
     }
+    localeCombo->model()->sort(0);
     file.setFileName("/etc/default/locale");
     QString locale;
     if (file.open(QFile::ReadOnly | QFile::Text)) {
@@ -531,7 +527,6 @@ void MInstall::prepareToInstall()
             }
         }
         file.close();
-        localeCombo->model()->sort(0);
     }
     if (localeCombo->findData(QVariant(locale)) != -1) {
         localeCombo->setCurrentIndex(localeCombo->findData(QVariant(locale)));

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -528,15 +528,11 @@ void MInstall::prepareToInstall()
         }
         file.close();
     }
-    if (localeCombo->findData(QVariant(locale)) != -1) {
-        localeCombo->setCurrentIndex(localeCombo->findData(QVariant(locale)));
+    const int iloc = localeCombo->findData(QVariant(locale));
+    if (iloc != -1) {
+        localeCombo->setCurrentIndex(iloc);
     } else {
-        localeCombo->setCurrentIndex(localeCombo->findData(QVariant("en_US")));
-    }
-
-    // clock 24/12 default
-    if (locale == "en_US.UTF-8" || locale == "LANG=ar_EG.UTF-8" || locale == "LANG=el_GR.UTF-8" || locale == "LANG=sq_AL.UTF-8") {
-        radio12h->setChecked(true);
+        localeCombo->setCurrentIndex(localeCombo->findData(QVariant("en_GB.UTF-8")));
     }
 
     // Detect snapshot-backup account(s)


### PR DESCRIPTION
fixed the bug reported by fehlix where nothing was selected if the local wasn't there.
Not sure if the /usr/share/antiX/locales.template file is needed anywhere else, but this fix means the installer no longer needs it directly.