### PR TITLE
If pretending do not reboot.

### DIFF
--- a/minstall.cpp
+++ b/minstall.cpp
@@ -2587,7 +2587,7 @@ void MInstall::gotoPage(int next)
         // finished
         updateCursor(Qt::WaitCursor);
         cleanup();
-        if (checkBoxExitReboot->isChecked()) {
+        if (!pretend && checkBoxExitReboot->isChecked()) {
             shell.run("/usr/local/bin/persist-config --shutdown --command reboot &");
         }
         qApp->exit(0);


### PR DESCRIPTION
This makes --pretend behave similarly to the original installer.