### PR TITLE
User configuration work.

### DIFF
--- a/meinstall.ui
+++ b/meinstall.ui
@@ -2303,7 +2303,124 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
+          <item row="1" column="0">
+           <widget class="QGroupBox" name="setClockBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Configure Clock</string>
+            </property>
+            <layout class="QGridLayout">
+             <property name="leftMargin">
+              <number>9</number>
+             </property>
+             <property name="topMargin">
+              <number>9</number>
+             </property>
+             <property name="rightMargin">
+              <number>9</number>
+             </property>
+             <property name="bottomMargin">
+              <number>9</number>
+             </property>
+             <property name="spacing">
+              <number>6</number>
+             </property>
+             <item row="3" column="2">
+              <widget class="QRadioButton" name="radio12h">
+               <property name="text">
+                <string notr="true">1:57</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="3">
+              <spacer name="horizontalSpacer_5">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="2" column="0" colspan="3">
+              <widget class="QCheckBox" name="localClockCheckBox">
+               <property name="text">
+                <string>System clock uses LOCAL</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>Format:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QRadioButton" name="radio24h">
+               <property name="text">
+                <string notr="true">13:57</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0" colspan="4">
+              <layout class="QHBoxLayout" name="_18">
+               <item>
+                <widget class="QLabel" name="tzLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Timezone:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QComboBox" name="timezoneCombo">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </item>
           <item row="3" column="0">
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="2" column="0">
            <widget class="QGroupBox" name="servicesBox">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
@@ -2359,80 +2476,6 @@
             </layout>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QGroupBox" name="setClockBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Configure Clock</string>
-            </property>
-            <layout class="QGridLayout">
-             <property name="leftMargin">
-              <number>9</number>
-             </property>
-             <property name="topMargin">
-              <number>9</number>
-             </property>
-             <property name="rightMargin">
-              <number>9</number>
-             </property>
-             <property name="bottomMargin">
-              <number>9</number>
-             </property>
-             <property name="spacing">
-              <number>6</number>
-             </property>
-             <item row="2" column="2">
-              <widget class="QRadioButton" name="radio12h">
-               <property name="text">
-                <string notr="true">1:57</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>Format:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QRadioButton" name="radio24h">
-               <property name="text">
-                <string notr="true">13:57</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0" colspan="3">
-              <widget class="QCheckBox" name="localClockCheckBox">
-               <property name="text">
-                <string>System clock uses LOCAL</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="3">
-              <spacer name="horizontalSpacer_5">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QGroupBox" name="localeBox">
             <property name="sizePolicy">
@@ -2460,6 +2503,16 @@
              <property name="spacing">
               <number>6</number>
              </property>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="localeCombo">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
              <item row="0" column="0">
               <widget class="QLabel" name="localeLabel">
                <property name="sizePolicy">
@@ -2479,72 +2532,8 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="1">
-              <widget class="QComboBox" name="localeCombo">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
             </layout>
            </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QGroupBox" name="tzBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Timezone Settings</string>
-            </property>
-            <layout class="QGridLayout" name="tzGridLayout">
-             <item row="0" column="0">
-              <widget class="QLabel" name="tzLabel">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Timezone:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QComboBox" name="timezoneCombo">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Expanding</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>

--- a/meinstall.ui
+++ b/meinstall.ui
@@ -425,7 +425,7 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item row="1" column="0" rowspan="2" colspan="2">
+          <item row="0" column="0" rowspan="2" colspan="2">
            <widget class="QGroupBox" name="rearrangediskBox">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
@@ -484,66 +484,7 @@
             </layout>
            </widget>
           </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QGroupBox" name="diskBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Choose disk for installation</string>
-            </property>
-            <layout class="QGridLayout">
-             <property name="leftMargin">
-              <number>9</number>
-             </property>
-             <property name="topMargin">
-              <number>9</number>
-             </property>
-             <property name="rightMargin">
-              <number>9</number>
-             </property>
-             <property name="bottomMargin">
-              <number>9</number>
-             </property>
-             <property name="spacing">
-              <number>6</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="useDiskLabel">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="font">
-                <font/>
-               </property>
-               <property name="text">
-                <string>Use disk:</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QComboBox" name="diskCombo">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
+          <item row="2" column="0" colspan="2">
            <widget class="QGroupBox" name="installationTypeBox">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
@@ -581,45 +522,17 @@
                <property name="text">
                 <string>Auto-install using entire disk </string>
                </property>
-               <property name="checked">
-                <bool>false</bool>
-               </property>
               </widget>
              </item>
-             <item row="1" column="1">
-              <widget class="QCheckBox" name="checkBoxEncryptAuto">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
+             <item row="3" column="1" colspan="2">
+              <widget class="QLabel" name="labelFDEpass">
                <property name="text">
-                <string>Encrypt</string>
+                <string>Encryption password:</string>
                </property>
               </widget>
              </item>
-             <item row="7" column="0" colspan="5">
-              <widget class="QRadioButton" name="existing_partitionsButton">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Custom install on existing partitions</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="2">
-              <spacer name="horizontalSpacer_12">
+             <item row="7" column="1">
+              <spacer name="horizontalSpacer_11">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -631,11 +544,95 @@
                </property>
               </spacer>
              </item>
-             <item row="4" column="3">
-              <widget class="QLineEdit" name="freeSpaceEdit">
+             <item row="5" column="0">
+              <spacer>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>12</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="5" column="4">
+              <widget class="QLabel" name="freeLabel">
                <property name="enabled">
                 <bool>false</bool>
                </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>MB </string>
+               </property>
+               <property name="wordWrap">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1" colspan="2">
+              <widget class="QLabel" name="labelFDEpass2">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="text">
+                <string>Confirm password:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="5">
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="5" column="1" colspan="2">
+              <widget class="QLabel" name="leaveLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Leave free space up to:</string>
+               </property>
+               <property name="wordWrap">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="0" colspan="5">
+              <widget class="QRadioButton" name="existing_partitionsButton">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Custom install on existing partitions</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="3">
+              <widget class="QLineEdit" name="freeSpaceEdit">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
                  <horstretch>0</horstretch>
@@ -656,7 +653,7 @@
                </property>
               </widget>
              </item>
-             <item row="6" column="3">
+             <item row="7" column="3">
               <spacer name="horizontalSpacer_13">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
@@ -669,52 +666,7 @@
                </property>
               </spacer>
              </item>
-             <item row="4" column="4">
-              <widget class="QLabel" name="freeLabel">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>MB </string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="1">
-              <spacer name="horizontalSpacer_11">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>5</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="4" column="5">
-              <spacer name="horizontalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="3" column="3" colspan="3">
+             <item row="4" column="3" colspan="3">
               <widget class="QLineEdit" name="FDEpassword2">
                <property name="maxLength">
                 <number>512</number>
@@ -725,68 +677,6 @@
               </widget>
              </item>
              <item row="2" column="3" colspan="3">
-              <widget class="QLineEdit" name="FDEpassword">
-               <property name="maxLength">
-                <number>512</number>
-               </property>
-               <property name="echoMode">
-                <enum>QLineEdit::Password</enum>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1" colspan="2">
-              <widget class="QLabel" name="labelFDEpass2">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string>Confirm password:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1" colspan="2">
-              <widget class="QLabel" name="labelFDEpass">
-               <property name="text">
-                <string>Encryption password:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0">
-              <spacer>
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>12</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="4" column="1" colspan="2">
-              <widget class="QLabel" name="leaveLabel">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Leave free space up to:</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="3" colspan="3">
               <widget class="QPushButton" name="buttonAdvancedFDE">
                <property name="enabled">
                 <bool>true</bool>
@@ -802,10 +692,75 @@
                </property>
               </widget>
              </item>
+             <item row="3" column="3" colspan="3">
+              <widget class="QLineEdit" name="FDEpassword">
+               <property name="maxLength">
+                <number>512</number>
+               </property>
+               <property name="echoMode">
+                <enum>QLineEdit::Password</enum>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="2">
+              <spacer name="horizontalSpacer_12">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>5</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="2" column="1">
+              <widget class="QCheckBox" name="checkBoxEncryptAuto">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Encrypt</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="useDiskLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font/>
+               </property>
+               <property name="text">
+                <string>Use disk:</string>
+               </property>
+               <property name="wordWrap">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="3" colspan="3">
+              <widget class="QComboBox" name="diskCombo">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>
-          <item row="4" column="0" colspan="2">
+          <item row="3" column="0" colspan="2">
            <spacer name="verticalSpacer_3">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -3041,7 +2996,6 @@
   <tabstop>buttonSetKeyboard</tabstop>
   <tabstop>backButton</tabstop>
   <tabstop>nextButton</tabstop>
-  <tabstop>diskCombo</tabstop>
   <tabstop>qtpartedButton</tabstop>
   <tabstop>entireDiskButton</tabstop>
   <tabstop>checkBoxEncryptAuto</tabstop>
@@ -3098,12 +3052,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>105</x>
-     <y>259</y>
+     <x>332</x>
+     <y>208</y>
     </hint>
     <hint type="destinationlabel">
-     <x>89</x>
-     <y>385</y>
+     <x>334</x>
+     <y>381</y>
     </hint>
    </hints>
   </connection>
@@ -3114,12 +3068,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>105</x>
-     <y>259</y>
+     <x>332</x>
+     <y>208</y>
     </hint>
     <hint type="destinationlabel">
-     <x>432</x>
-     <y>385</y>
+     <x>549</x>
+     <y>381</y>
     </hint>
    </hints>
   </connection>
@@ -3130,12 +3084,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>105</x>
-     <y>259</y>
+     <x>332</x>
+     <y>208</y>
     </hint>
     <hint type="destinationlabel">
-     <x>557</x>
-     <y>385</y>
+     <x>581</x>
+     <y>381</y>
     </hint>
    </hints>
   </connection>
@@ -3146,12 +3100,44 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>105</x>
-     <y>259</y>
+     <x>332</x>
+     <y>208</y>
     </hint>
     <hint type="destinationlabel">
-     <x>89</x>
-     <y>289</y>
+     <x>327</x>
+     <y>278</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>entireDiskButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>diskCombo</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>404</x>
+     <y>197</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>472</x>
+     <y>241</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>entireDiskButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>useDiskLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>377</x>
+     <y>201</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>319</x>
+     <y>236</y>
     </hint>
    </hints>
   </connection>

--- a/meinstall.ui
+++ b/meinstall.ui
@@ -285,7 +285,7 @@
          <number>0</number>
         </property>
         <widget class="QWidget" name="Step_Terms">
-         <layout class="QGridLayout" name="_4">
+         <layout class="QGridLayout" name="_3">
           <property name="leftMargin">
            <number>0</number>
           </property>
@@ -412,7 +412,7 @@
          </layout>
         </widget>
         <widget class="QWidget" name="Step_Disk">
-         <layout class="QGridLayout" name="_3">
+         <layout class="QGridLayout" name="_4">
           <property name="leftMargin">
            <number>0</number>
           </property>
@@ -1353,7 +1353,7 @@
          </layout>
         </widget>
         <widget class="QWidget" name="Step_FDE">
-         <layout class="QGridLayout" name="_16">
+         <layout class="QGridLayout" name="_6">
           <property name="leftMargin">
            <number>0</number>
           </property>
@@ -1707,77 +1707,6 @@
                  <string>urandom</string>
                 </property>
                </item>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="Step_Progress">
-         <layout class="QGridLayout" name="_6">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QGroupBox" name="tipsBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Tips</string>
-            </property>
-            <layout class="QGridLayout">
-             <property name="leftMargin">
-              <number>9</number>
-             </property>
-             <property name="topMargin">
-              <number>9</number>
-             </property>
-             <property name="rightMargin">
-              <number>9</number>
-             </property>
-             <property name="bottomMargin">
-              <number>9</number>
-             </property>
-             <property name="spacing">
-              <number>6</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QTextEdit" name="tipsEdit">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="acceptDrops">
-                <bool>false</bool>
-               </property>
-               <property name="frameShape">
-                <enum>QFrame::StyledPanel</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Plain</enum>
-               </property>
-               <property name="undoRedoEnabled">
-                <bool>false</bool>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
               </widget>
              </item>
             </layout>
@@ -2857,6 +2786,77 @@
             <property name="text">
              <string>Save live desktop changes</string>
             </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="Step_Progress">
+         <layout class="QGridLayout" name="_16">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QGroupBox" name="tipsBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Tips</string>
+            </property>
+            <layout class="QGridLayout">
+             <property name="leftMargin">
+              <number>9</number>
+             </property>
+             <property name="topMargin">
+              <number>9</number>
+             </property>
+             <property name="rightMargin">
+              <number>9</number>
+             </property>
+             <property name="bottomMargin">
+              <number>9</number>
+             </property>
+             <property name="spacing">
+              <number>6</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QTextEdit" name="tipsEdit">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="acceptDrops">
+                <bool>false</bool>
+               </property>
+               <property name="frameShape">
+                <enum>QFrame::StyledPanel</enum>
+               </property>
+               <property name="frameShadow">
+                <enum>QFrame::Plain</enum>
+               </property>
+               <property name="undoRedoEnabled">
+                <bool>false</bool>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -633,6 +633,17 @@ int MInstall::manageConfig(enum ConfigAction mode)
         const char *diskChoices[] = {"WholeDisk", "Custom"};
         QRadioButton *diskRadios[] = {entireDiskButton, existing_partitionsButton};
         lambdaSetRadios("PartitionMode", 2, diskChoices, diskRadios);
+        if (mode == ConfigLoadA) {
+            // Password (load-only)
+            const QString &epass = config->value("Pass").toString();
+            if (entireDiskButton->isChecked()) {
+                FDEpassword->setText(epass);
+                FDEpassword2->setText(epass);
+            } else {
+                FDEpassCust->setText(epass);
+                FDEpassCust2->setText(epass);
+            }
+        }
         config->endGroup();
         if (configStuck < 0) configStuck = 1;
 
@@ -747,6 +758,13 @@ int MInstall::manageConfig(enum ConfigAction mode)
             else if (!val.compare("Use", Qt::CaseInsensitive)) oldHomeAction = OldHomeUse;
             else if (!val.compare("Delete", Qt::CaseInsensitive)) oldHomeAction = OldHomeDelete;
             else configStuck = -1;
+            // Passwords (load-only)
+            const QString &upass = config->value("UserPass").toString();
+            userPasswordEdit->setText(upass);
+            userPasswordEdit2->setText(upass);
+            const QString &rpass = config->value("RootPass").toString();
+            rootPasswordEdit->setText(rpass);
+            rootPasswordEdit2->setText(rpass);
         }
         config->endGroup();
         if (configStuck < 0) configStuck = 9;

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -3404,19 +3404,17 @@ void MInstall::buildBootLists()
     // refresh lists and enable or disable options according to device presence
     on_grubMbrButton_toggled();
     canMBR = (grubBootCombo->count() > 0);
+    grubMbrButton->setEnabled(canMBR);
     on_grubPbrButton_toggled();
     canPBR = (grubBootCombo->count() > 0);
+    grubPbrButton->setEnabled(canPBR);
+    on_grubEspButton_toggled();
+    canESP = (uefi && grubBootCombo->count() > 0);
+    grubEspButton->setEnabled(canESP);
 
-    canESP = false;
-    if (uefi) {
-        on_grubEspButton_toggled();
-        if (grubBootCombo->count() > 0) {
-            canESP = true;
-            grubEspButton->click();
-        }
-    }
-    // default to MBR if no ESP exists
-    if (!canESP) {
+    if (canESP) grubEspButton->click();
+    else {
+        // load MBR list as a default if no ESP exists
         on_grubMbrButton_toggled();
         grubMbrButton->click();
     }

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -648,7 +648,8 @@ int MInstall::manageConfig(enum ConfigAction mode)
         } else {
             int icombo;
             if (useData) {
-                icombo = combobox->findData(config->value(key, combobox->currentData()));
+                icombo = combobox->findData(config->value(key, combobox->currentData()),
+                                            Qt::MatchExactly);
             } else {
                 const QString &val = config->value(key, combobox->currentText()).toString();
                 icombo = combobox->findText(val, Qt::MatchStartsWith);
@@ -1643,7 +1644,7 @@ void MInstall::makeFstab()
             out << bootdevUUID + " /boot ext4 " + root_mntops + " 1 1\n";
         }
         if (grubEspButton->isChecked()) {
-            const QString espdev = "/dev/" + grubBootCombo->currentText().section(" ", 0, 0).trimmed();
+            const QString espdev = "/dev/" + grubBootCombo->currentText().section(" ", 0, 0);
             const QString espdevUUID = "UUID=" + getCmdOut(cmdBlkID + espdev);
             qDebug() << "espdev" << espdev << espdevUUID;
             out << espdevUUID + " /boot/efi vfat defaults,noatime,dmask=0002,fmask=0113 0 0\n";
@@ -1765,7 +1766,7 @@ bool MInstall::installLoader()
     }
 
     //add switch to change root partition info
-    QString boot = "/dev/" + grubBootCombo->currentText().section(" ", 0, 0).trimmed();
+    QString boot = "/dev/" + grubBootCombo->currentText().section(" ", 0, 0);
 
     if (grubMbrButton->isChecked() && !isGpt(boot)) {
         QString part_num;

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -575,11 +575,12 @@ int MInstall::manageConfig(enum ConfigAction mode)
     if (!config) return 0;
 
     auto lambdaSetComboBox = [this, mode](const QString &key, QComboBox *combo, const bool useData) -> void {
-        const QVariant &val = useData ? combo->currentData() : QVariant(combo->currentText());
-        if (mode == ConfigSave) config->setValue(key, val);
+        const QVariant &comboval = useData ? combo->currentData() : QVariant(combo->currentText());
+        if (mode == ConfigSave) config->setValue(key, comboval);
         else {
-            const int icombo = useData ? combo->findData(config->value(key, val), Qt::MatchExactly)
-                             : combo->findText(config->value(key, val).toString(), Qt::MatchExactly);
+            const QVariant &val = config->value(key, comboval);
+            const int icombo = useData ? combo->findData(val, Qt::UserRole, Qt::MatchFixedString)
+                             : combo->findText(val.toString(), Qt::MatchFixedString);
             if (icombo >= 0) combo->setCurrentIndex(icombo);
             else if (!configStuck) configStuck = -1;
         }
@@ -615,8 +616,7 @@ int MInstall::manageConfig(enum ConfigAction mode)
         else {
             const QString &val = config->value(key, choice).toString();
             for (int ixi = 0; ixi < nchoices; ++ixi) {
-                if (val.compare(QString(choices[ixi]), Qt::CaseInsensitive)
-                        && radios[ixi]->isVisible() && radios[ixi]->isEnabled()) {
+                if (!val.compare(QString(choices[ixi]), Qt::CaseInsensitive)) {
                     radios[ixi]->setChecked(true);
                     return;
                 }
@@ -743,9 +743,9 @@ int MInstall::manageConfig(enum ConfigAction mode)
             config->setValue("OldHomeAction", action);
         } else {
             const QString &val = config->value("OldHomeAction", "Nothing").toString();
-            if (val.compare("Nothing", Qt::CaseInsensitive)) oldHomeAction = OldHomeNothing;
-            else if (val.compare("Use", Qt::CaseInsensitive)) oldHomeAction = OldHomeUse;
-            else if (val.compare("Delete", Qt::CaseInsensitive)) oldHomeAction = OldHomeDelete;
+            if (!val.compare("Nothing", Qt::CaseInsensitive)) oldHomeAction = OldHomeNothing;
+            else if (!val.compare("Use", Qt::CaseInsensitive)) oldHomeAction = OldHomeUse;
+            else if (!val.compare("Delete", Qt::CaseInsensitive)) oldHomeAction = OldHomeDelete;
             else configStuck = -1;
         }
         config->endGroup();

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -122,7 +122,6 @@ void MInstall::startup()
 
     this->setEnabled(true);
     updateCursor();
-
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -2590,8 +2589,8 @@ QString BlockDeviceInfo::comboFormat() const
 
 QStringList MInstall::splitDevice(const QString &devname) const
 {
-    static const QRegularExpression rxdev1("^(mmcblk.*|nvme.*)p([0-9]*)$");
-    static const QRegularExpression rxdev2("^([a-z]*)([0-9]*)$");
+    static const QRegularExpression rxdev1("^(?:/dev/)+(mmcblk.*|nvme.*)p([0-9]*)$");
+    static const QRegularExpression rxdev2("^(?:/dev/)+([a-z]*)([0-9]*)$");
     QRegularExpressionMatch rxmatch(rxdev1.match(devname));
     if (!rxmatch.hasMatch()) rxmatch = rxdev2.match(devname);
     QStringList list(rxmatch.capturedTexts());
@@ -2871,6 +2870,8 @@ void MInstall::updatePartInfo()
     }
     // if there was no suitable root, add an entry to let the user know
     if (rootCombo->count() == 0) rootCombo->addItem("none");
+
+    prevItemRoot.clear();
     on_rootCombo_activated(rootCombo->currentText());
 }
 

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -329,7 +329,7 @@ bool MInstall::checkDisk()
     int ans;
     QString output;
 
-    QString drv = "/dev/" + diskCombo->currentText().section(" ", 0, 0);
+    QString drv = "/dev/" + (entireDiskButton->isChecked() ? diskCombo : rootCombo)->currentText().section(" ", 0, 0);
     output = getCmdOut("smartctl -H " + drv + "|grep -w FAILED");
     if (output.contains("FAILED")) {
         msg = output + tr("\n\nThe disk with the partition you selected for installation is failing.\n\n") +

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -340,13 +340,11 @@ bool MInstall::checkDisk()
                 tr("Do you want to abort the installation?");
         ans = QMessageBox::critical(this, windowTitle(), msg,
                                     QMessageBox::Yes, QMessageBox::No);
-        if (ans == QMessageBox::Yes) {
-            return false;
-        }
+        if (ans == QMessageBox::Yes) return false;
     }
     else {
         output = getCmdOut("smartctl -A " + drv + "| grep -E \"^  5|^196|^197|^198\" | awk '{ if ( $10 != 0 ) { print $1,$2,$10} }'");
-        if (output.isEmpty()) {
+        if (!output.isEmpty()) {
             msg = tr("Smartmon tool output:\n\n") + output + "\n\n" +
                     tr("The disk with the partition you selected for installation passes the S.M.A.R.T. monitor test (smartctl)\n") +
                     tr("but the tests indicate it will have a higher than average failure rate in the upcoming year.\n") +
@@ -354,9 +352,7 @@ bool MInstall::checkDisk()
                     tr("Do you want to continue?");
             ans = QMessageBox::warning(this, windowTitle(), msg,
                                        QMessageBox::Yes, QMessageBox::No);
-            if (ans != QMessageBox::Yes) {
-                return false;
-            }
+            if (ans != QMessageBox::Yes) return false;
         }
     }
     return true;

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -2352,10 +2352,10 @@ void MInstall::pageDisplayed(int next)
                              "<p>When encryption is used with autoinstall, the separate boot partition will be automatically created</p>"));
         if (phase < 0) {
             updateCursor(Qt::WaitCursor);
+            phase = 0;
             updatePartitionWidgets();
+            updateCursor();
         }
-        phase = 0;
-        updateCursor();
         break;
 
     case 2:  // choose partition
@@ -2959,6 +2959,7 @@ bool MInstall::abort(bool onclose)
     } else {
         phase = -1;
     }
+    if (!onclose) this->setEnabled(true);
     return true;
 }
 

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -19,7 +19,8 @@
 
 #include <QDebug>
 #include <QFileInfo>
-#include <QtConcurrent/QtConcurrent>
+#include <QTimer>
+#include <QProcess>
 #include <fcntl.h>
 #include <sys/statvfs.h>
 #include <sys/stat.h>

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -61,9 +61,8 @@ MInstall::MInstall(const QStringList &args, const QString &cfgfile)
     setWindowTitle(tr("%1 Installer").arg(PROJECTNAME));
 
     // config file
-    if (QFile::exists(cfgfile)) {
-        config = new QSettings(cfgfile, QSettings::NativeFormat, this);
-    }
+    config = new QSettings(QFile::exists(cfgfile) ? cfgfile : "/dev/null",
+                           QSettings::NativeFormat, this);
 
     // set some distro-centric text
     copyrightBrowser->setPlainText(tr("%1 is an independent Linux distribution based on Debian Stable.\n\n%1 uses some components from MEPIS Linux which are released under an Apache free license. Some MEPIS components have been modified for %1.\n\nEnjoy using %1").arg(PROJECTNAME));

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -1296,7 +1296,7 @@ bool MInstall::makePartitions()
             const qint64 end = start + size;
             rc = execute("parted -s --align optimal /dev/" + devsplit[0] + " mkpart " + type
                          + " " + QString::number(start) + "MiB " + QString::number(end) + "MiB");
-            start += end;
+            start = end;
         } else if (size < 0){
             // command to set the partition type
             QString cmd;

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -2633,7 +2633,7 @@ void BlockDeviceInfo::addToCombo(QComboBox *combo) const
     if (!label.isEmpty()) strout += " - " + label;
     if (!model.isEmpty()) strout += (label.isEmpty() ? " - " : "; ") + model;
     QIcon icon;
-    if (isFuture) icon = QIcon::fromTheme("appointment-soon");
+    if (isFuture) icon = QIcon::fromTheme("appointment-soon-symbolic");
     combo->addItem(icon, strout + ")", name);
 }
 

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -118,6 +118,7 @@ void MInstall::startup()
         auto_mount = getCmdOut("command -v xfconf-query >/dev/null && su $(logname) -c 'xfconf-query --channel thunar-volman --property /automount-drives/enabled'");
         execute("command -v xfconf-query >/dev/null && su $(logname) -c 'xfconf-query --channel thunar-volman --property /automount-drives/enabled --set false'", false);
     }
+    buildBlockDevList();
 
     this->setEnabled(true);
     updateCursor();
@@ -2591,6 +2592,58 @@ void MInstall::updatePartitionWidgets()
     } else {
         existing_partitionsButton->hide();
         entireDiskButton->setChecked(true);
+    }
+}
+
+void MInstall::buildBlockDevList()
+{
+    execute("/sbin/partprobe", true);
+
+    // expressions for matching various partition types
+    QRegularExpression rxESP("^(c12a7328-f81f-11d2-ba4b-00a0c93ec93b|0xef)$");
+    QRegularExpression rxSwap("^(0x82|0657fd6d-a4ab-43c4-84e5-0933c84b4f4f)$");
+    QRegularExpression rxNative("^(0x83|0fc63daf-8483-4772-8e79-3d69d8477de4" // Linux data
+                                "|0x82|0657fd6d-a4ab-43c4-84e5-0933c84b4f4f" // Linux swap
+                                "|44479540-f297-41b2-9af7-d131d5f0458a" // Linux /root x86
+                                "|4f68bce3-e8cd-4db1-96e7-fbcaf984b709" // Linux /root x86-64
+                                "|933ac7e1-2eb4-4f13-b844-0e14e2aef915)$"); // Linux /home
+    QRegularExpression rxNativeFS("^(btrfs|ext2|ext3|ext4|jfs|nilfs2"
+                                  "reiser4|reiserfs|ufs|xfs)$");
+
+    // populate the block device list
+    listBlkDevs.clear();
+    QStringList blkdevs = getCmdOuts("lsblk -brno TYPE,NAME,SIZE,PARTTYPE,FSTYPE,PARTFLAGS,UUID,MODEL"
+                                     " | grep -E '^(disk|part)'");
+    for (const QString &blkdev : blkdevs) {
+        QStringList bdsegs = blkdev.split(' ');
+        BlockDeviceInfo bdinfo;
+        const int segsize = bdsegs.size();
+        if (segsize < 6) continue;
+        bdinfo.name = bdsegs.at(1);
+        bdinfo.size = bdsegs.at(2).toLongLong();
+        bdinfo.flags.disk = (bdsegs.at(0) == "disk");
+        bdinfo.flags.esp = (bdsegs.at(3).count(rxESP) >= 1);
+        bdinfo.flags.swap = (bdsegs.at(3).count(rxSwap) >= 1);
+        bdinfo.flags.native = (bdsegs.at(3).count(rxNative) >= 1
+                               || bdsegs.at(4).count(rxNativeFS) >= 1);
+        const int flags = bdsegs.at(5).toInt(NULL, 0);
+        bdinfo.flags.boot = (flags & 0x80);
+        if (segsize > 6) bdinfo.uuid = bdsegs.at(6);
+        if (segsize > 7) {
+            QString seg = bdsegs.at(7);
+            seg.replace('%', "\\x25");
+            seg.replace("\\x", "%");
+            bdinfo.model = QUrl::fromPercentEncoding(seg.toUtf8()).trimmed();
+        }
+        listBlkDevs << bdinfo;
+    }
+
+    // debug
+    for (BlockDeviceInfo &bdi : listBlkDevs) {
+        qDebug() << bdi.name << ", UUID:" << bdi.uuid << ", Size (MB):" << bdi.size / 1048576
+                 << ", Model:" << bdi.model << ", Disk:" << bdi.flags.disk
+                 << ", Native:" << bdi.flags.native << ", ESP:" << bdi.flags.esp
+                 << ", Swap:" << bdi.flags.swap << ", Boot:" << bdi.flags.boot;
     }
 }
 

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -2627,8 +2627,8 @@ void MInstall::buildBlockDevList()
     static const QRegularExpression rxNativeFS("^(btrfs|ext2|ext3|ext4|jfs|nilfs2|reiser4|reiserfs|ufs|xfs)$");
 
     QString bootUUID;
-    if (QFile::exists("./initrd.out")) {
-        QSettings livecfg("./initrd.out", QSettings::NativeFormat);
+    if (QFile::exists("/live/config/initrd.out")) {
+        QSettings livecfg("/live/config/initrd.out", QSettings::NativeFormat);
         bootUUID = livecfg.value("BOOT_UUID").toString();
     }
     // populate the block device list

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -1179,7 +1179,7 @@ bool MInstall::makeDefaultPartitions(bool &formatBoot)
     for (const BlockDeviceInfo &bdinfo : listBlkDevs) {
         if (!bdinfo.isDisk && bdinfo.name.startsWith(drv)) {
             execute("swapoff /dev/" + bdinfo.name, true);
-            execute("pumount /dev/" + bdinfo.name, true);
+            execute("umount /dev/" + bdinfo.name, true);
         }
     }
 
@@ -1344,7 +1344,7 @@ bool MInstall::makeChosenPartitions(QString &rootType, QString &homeType, bool &
 
     auto lambdaPreparePart = [this](const QString &strdev) -> void {
         execute("swapoff " + strdev, true);
-        execute("pumount " + strdev, true);
+        execute("umount " + strdev, true);
         execute(QStringLiteral("dd if=/dev/zero of=%1 bs=8192 count=1").arg(strdev));
 
         // command to set the partition type
@@ -1380,7 +1380,7 @@ bool MInstall::makeChosenPartitions(QString &rootType, QString &homeType, bool &
     // prepare home if not being preserved, and on a different partition
     if (homeDevicePreserve != rootDevicePreserve) {
         if (checkBoxEncryptHome->isChecked()) isHomeEncrypted = true;
-        if (saveHome) execute("pumount " + homeDevicePreserve);
+        if (saveHome) execute("umount " + homeDevicePreserve);
         else {
             lambdaPreparePart(homeDevicePreserve);
             homeType = homeTypeCombo->currentText().toUtf8();

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -85,6 +85,7 @@ void MInstall::startup()
 {
     qDebug() << "+++" << __PRETTY_FUNCTION__ << "+++";
 
+    checkUefi();
     if (!pretend) {
         // disable automounting in Thunar
         auto_mount = getCmdOut("command -v xfconf-query >/dev/null && su $(logname) -c 'xfconf-query --channel thunar-volman --property /automount-drives/enabled'");
@@ -466,7 +467,6 @@ bool MInstall::processNextPhase()
         cleanup(false); // cleanup previous mounts
         isRootFormatted = false;
         isHomeFormatted = false;
-        checkUefi();
 
         // the core of the installation
         if (!pretend) {

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -90,7 +90,6 @@ void MInstall::startup()
     on_comboFDEcipher_currentIndexChanged(comboFDEcipher->currentText());
     on_comboFDEchain_currentIndexChanged(comboFDEchain->currentText());
     on_comboFDEivgen_currentIndexChanged(comboFDEivgen->currentText());
-    stashAdvancedFDE(true);
 
     rootLabelEdit->setText("root" + PROJECTSHORTNAME + PROJECTVERSION);
     homeLabelEdit->setText("home" + PROJECTSHORTNAME);
@@ -113,14 +112,15 @@ void MInstall::startup()
     existing_partitionsButton->hide();
 
     setupkeyboardbutton();
+    updatePartitionWidgets();
+    manageConfig(ConfigLoadA);
+    stashAdvancedFDE(true);
+
     if (!pretend) {
         // disable automounting in Thunar
         auto_mount = getCmdOut("command -v xfconf-query >/dev/null && su $(logname) -c 'xfconf-query --channel thunar-volman --property /automount-drives/enabled'");
         execute("command -v xfconf-query >/dev/null && su $(logname) -c 'xfconf-query --channel thunar-volman --property /automount-drives/enabled --set false'", false);
     }
-    updatePartitionWidgets();
-    manageConfig(ConfigLoadA);
-
     this->setEnabled(true);
     updateCursor();
 }
@@ -676,8 +676,8 @@ int MInstall::manageConfig(enum ConfigAction mode)
         if (configStuck < 0) configStuck = 3;
     }
 
-    // GRUB step
     if (mode == ConfigSave || mode == ConfigLoadB) {
+        // GRUB step
         config->beginGroup("GRUB");
         const char *install = NULL;
         if(grubCheckBox->isChecked()) {
@@ -704,9 +704,7 @@ int MInstall::manageConfig(enum ConfigAction mode)
         lambdaSetComboBox("Location", grubBootCombo);
         config->endGroup();
         if (configStuck < 0) configStuck = 5;
-    }
 
-    if (mode == ConfigSave || mode == ConfigLoadA) {
         // Services step
         config->beginGroup("Services");
         QTreeWidgetItemIterator it(csView);

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -2264,14 +2264,14 @@ int MInstall::showPage(int curr, int next)
             return 9; // skip Step_User_Accounts and go to Step_Progress
         }
     } else if (next == 10 && curr == 9) { // at Step_Progress (forward)
-        return 4; // Return to Step_Boot instead of the end
+        if (phase < 4) return 4; // Return to Step_Boot instead of the end
     } else if (next == 8 && curr == 9) { // at Step_Progress (backward)
         if (!pretend && haveSnapshotUserAccounts) {
             return 7; // skip Step_User_Accounts and go to Step_Localization
         }
     } else if (curr == 6) { // at Step_Services
         stashServices(next == 7);
-        return 8; // goes back to the screen that called Services screen
+        return 7; // goes back to the screen that called Services screen
     }
     return next;
 }

--- a/minstall.cpp
+++ b/minstall.cpp
@@ -1192,7 +1192,7 @@ bool MInstall::calculateDefaultPartitions()
     // add future partitions to the block device list and store new names
     if (uefi) {
         BlockDeviceInfo &bdinfo = lambdaAddFutureBD(espFormatSize, "vfat");
-        espDevice = bdinfo.name;
+        espDevice = "/dev/" + bdinfo.name;
         bdinfo.isNative = false;
         bdinfo.isESP = true;
     }

--- a/minstall.h
+++ b/minstall.h
@@ -209,6 +209,7 @@ private:
 
     QWidget *nextFocus = NULL;
     BlockDeviceList listBlkDevs, listBlkDevsBackup;
+    QStringList listToUnmount;
     QString home_mntops = "defaults";
     QString root_mntops = "defaults";
     QStringList listHomes;

--- a/minstall.h
+++ b/minstall.h
@@ -48,7 +48,7 @@ struct BlockDeviceInfo {
     bool isESP : 1;
     bool isNative : 1;
     bool isSwap : 1;
-    QString comboFormat() const;
+    void addToCombo(QComboBox *combo) const;
 };
 
 class BlockDeviceList : public QList<BlockDeviceInfo> {

--- a/minstall.h
+++ b/minstall.h
@@ -52,6 +52,11 @@ struct BlockDeviceInfo {
     QString comboFormat(bool showfs = true) const;
 };
 
+class BlockDeviceList : public QList<BlockDeviceInfo> {
+public:
+    int findDevice(const QString &devname) const;
+};
+
 class MInstall : public QDialog, public Ui::MeInstall {
     Q_OBJECT
 protected:
@@ -201,7 +206,7 @@ private:
     bool haveSysConfig = false;
 
     QWidget *nextFocus = NULL;
-    QList<BlockDeviceInfo> listBlkDevs;
+    BlockDeviceList listBlkDevs;
     QString home_mntops = "defaults";
     QString root_mntops = "defaults";
     QStringList listHomes;

--- a/minstall.h
+++ b/minstall.h
@@ -43,9 +43,10 @@ struct BlockDeviceInfo {
     QString model;
     qint64 size;
     bool isDisk : 1;
-    bool isNative : 1;
+    bool isGPT : 1;
     bool isBoot : 1;
     bool isESP : 1;
+    bool isNative : 1;
     bool isSwap : 1;
     QString comboFormat() const;
 };
@@ -211,9 +212,7 @@ private:
     int iLastProgress = -1;
 
     // info needed for Phase 2 of the process
-    QStringList listBootDrives;
-    QStringList listBootESP;
-    QStringList listBootPart;
+    bool canMBR, canPBR, canESP;
     bool haveSamba = false;
     bool haveSnapshotUserAccounts = false;
     enum OldHomeAction {

--- a/minstall.h
+++ b/minstall.h
@@ -82,8 +82,6 @@ public:
     bool checkPassword(const QString &pass);
     bool installLoader();
     bool validateChosenPartitions();
-    bool makeDefaultPartitions();
-    bool makeEsp(const QString &drv, int size);
     bool makeLinuxPartition(const QString &dev, const QString &type, bool bad, const QString &label);
     bool makeLuksPartition(const QString &dev, const QByteArray &password);
     bool openLuksPartition(const QString &dev, const QString &fs_name, const QByteArray &password, const QString &options = QString(), const bool failHard = true);
@@ -123,6 +121,7 @@ public:
     QString swapDevicePreserve;
     QString rootDevicePreserve;
     QString homeDevicePreserve;
+    QString espDevice;
 
     int showPage(int curr, int next);
     void gotoPage(int next);
@@ -254,7 +253,7 @@ private:
     void prepareToInstall();
     bool saveHomeBasic();
     bool calculateFuturePartitions();
-    bool makeChosenPartitions();
+    bool makePartitions();
     bool formatPartitions(const QByteArray &encPass);
     bool installLinux(const int progend);
     bool copyLinux(const int progend);

--- a/minstall.h
+++ b/minstall.h
@@ -47,7 +47,7 @@ struct BlockDeviceInfo {
     bool isBoot : 1;
     bool isESP : 1;
     bool isSwap : 1;
-    QString comboFormat(bool showfs = true) const;
+    QString comboFormat() const;
 };
 
 class BlockDeviceList : public QList<BlockDeviceInfo> {

--- a/minstall.h
+++ b/minstall.h
@@ -254,7 +254,7 @@ private:
     bool saveHomeBasic();
     bool calculateFuturePartitions();
     bool makePartitions();
-    bool formatPartitions(const QByteArray &encPass);
+    bool formatPartitions();
     bool installLinux(const int progend);
     bool copyLinux(const int progend);
     void failUI(const QString &msg);

--- a/minstall.h
+++ b/minstall.h
@@ -35,6 +35,20 @@ public:
     void erase();
 };
 
+struct BlockDeviceInfo {
+    QString name;
+    QString uuid;
+    QString model;
+    qint64 size;
+    struct {
+        bool disk : 1;
+        bool native : 1;
+        bool boot : 1;
+        bool esp : 1;
+        bool swap : 1;
+    } flags;
+};
+
 class MInstall : public QDialog, public Ui::MeInstall {
     Q_OBJECT
 protected:
@@ -184,6 +198,7 @@ private:
     bool haveSysConfig = false;
 
     QWidget *nextFocus = NULL;
+    QList<BlockDeviceInfo> listBlkDevs;
     QString home_mntops = "defaults";
     QString root_mntops = "defaults";
     QStringList listHomes;
@@ -239,6 +254,7 @@ private:
     // private functions
     void updateStatus(const QString &msg, int val = -1);
     void updateCursor(const Qt::CursorShape shape = Qt::ArrowCursor);
+    void buildBlockDevList();
     bool pretendToInstall(int start, int stop, int sleep);
     void prepareToInstall();
     bool saveHomeBasic();

--- a/minstall.h
+++ b/minstall.h
@@ -91,16 +91,13 @@ public:
     bool validateComputerName();
     bool setComputerName();
     bool setUserInfo();
-    void addItemCombo(QComboBox *cb, const QString *part);
     void buildBootLists();
     void buildServiceList();
     void disablehiberanteinitramfs();
     void makeFstab();
     bool processNextPhase();
-    void removeItemCombo(QComboBox *cb, const QString *part);
     void setLocale();
     void setServices();
-    void updatePartCombo(QString *prevItem, const QString &part);
     void writeKeyFile();
 
     bool INSTALL_FROM_ROOT_DEVICE;
@@ -143,7 +140,6 @@ private slots:
     void on_qtpartedButton_clicked();
     void on_viewServicesButton_clicked();
 
-    void on_homeCombo_currentIndexChanged(const QString &arg1);
     void on_userPasswordEdit2_textChanged(const QString &arg1);
     void on_rootPasswordEdit2_textChanged(const QString &arg1);
     void on_userPasswordEdit_textChanged();
@@ -169,10 +165,10 @@ private slots:
     void on_checkBoxEncryptSwap_toggled(bool checked);
 
     void on_rootTypeCombo_activated(QString item = "");
-    void on_rootCombo_activated(const QString &arg1 = "");
-    void on_homeCombo_activated(const QString &arg1);
-    void on_swapCombo_activated(const QString &arg1);
-    void on_bootCombo_activated(const QString &arg1);
+    void on_rootCombo_currentIndexChanged(const QString &text);
+    void on_homeCombo_currentIndexChanged(const QString &text);
+    void on_swapCombo_currentIndexChanged(const QString &text);
+    void on_bootCombo_currentIndexChanged(int);
 
     void on_grubCheckBox_toggled(bool checked);
     void on_grubMbrButton_toggled();
@@ -188,9 +184,11 @@ private:
     // command line options
     bool pretend, automatic, nocopy, sync;
     // configuration management
+    QSettings *config = NULL;
     enum ConfigAction { ConfigSave, ConfigLoadA, ConfigLoadB };
     int configStuck = 0;
 
+    QString auto_mount;
     bool formatSwap = false;
     bool isHomeEncrypted = false;
     bool isRootEncrypted = false;
@@ -211,18 +209,6 @@ private:
     int ixTip = 0;
     int ixTipStart = -1;
     int iLastProgress = -1;
-
-    // for partition combo updates
-    QHash<QString, int> removedRoot; // remember items removed from combo box: item, index
-    QHash<QString, int> removedHome;
-    QHash<QString, int> removedSwap;
-    QHash<QString, int> removedBoot;
-    QSettings *config = NULL;
-    QString auto_mount;
-    QString prevItemRoot; // remember previously selected item in combo box
-    QString prevItemHome;
-    QString prevItemSwap;
-    QString prevItemBoot;
 
     // info needed for Phase 2 of the process
     QStringList listBootDrives;
@@ -254,6 +240,7 @@ private:
     void updateStatus(const QString &msg, int val = -1);
     void updateCursor(const Qt::CursorShape shape = Qt::ArrowCursor);
     void updatePartitionWidgets();
+    void updatePartitionCombos(QComboBox *changed);
     QStringList splitDevice(const QString &device) const;
     void buildBlockDevList();
     bool pretendToInstall(int start, int stop, int sleep);

--- a/minstall.h
+++ b/minstall.h
@@ -44,7 +44,7 @@ protected:
     void reject();
 
 public:
-    MInstall(const QStringList &args);
+    MInstall(const QStringList &args, const QString &cfgfile = "/etc/minstall.conf");
     ~MInstall();
 
     void checkUefi();
@@ -202,7 +202,7 @@ private:
     QHash<QString, int> removedHome;
     QHash<QString, int> removedSwap;
     QHash<QString, int> removedBoot;
-    QSettings *config;
+    QSettings *config = NULL;
     QString auto_mount;
     QString prevItemRoot; // remember previously selected item in combo box
     QString prevItemHome;
@@ -231,7 +231,8 @@ private:
     int indexFDErandom;
     long iFDEroundtime;
 
-
+    // slots
+    void startup();
     // helpers
     bool execute(const QString &cmd, const bool rawexec = false, const QByteArray &input = QByteArray());
     QString getCmdOut(const QString &cmd, bool everything = false);

--- a/minstall.h
+++ b/minstall.h
@@ -208,7 +208,7 @@ private:
     qint64 espFormatSize = 0;
 
     QWidget *nextFocus = NULL;
-    BlockDeviceList listBlkDevs, listBlkDevsBackup;
+    BlockDeviceList listBlkDevs;
     QStringList listToUnmount;
     QString home_mntops = "defaults";
     QString root_mntops = "defaults";

--- a/minstall.h
+++ b/minstall.h
@@ -41,13 +41,13 @@ struct BlockDeviceInfo {
     QString label;
     QString model;
     qint64 size;
-    bool isFuture : 1;
-    bool isDisk : 1;
-    bool isGPT : 1;
-    bool isBoot : 1;
-    bool isESP : 1;
-    bool isNative : 1;
-    bool isSwap : 1;
+    bool isFuture = false;
+    bool isDisk = false;
+    bool isGPT = false;
+    bool isBoot = false;
+    bool isESP = false;
+    bool isNative = false;
+    bool isSwap = false;
     void addToCombo(QComboBox *combo) const;
 };
 

--- a/minstall.h
+++ b/minstall.h
@@ -117,10 +117,10 @@ public:
     bool REMOVE_NOSPLASH;
 
     // global for now until boot combo box is sorted out
-    QString bootDevicePreserve;
-    QString swapDevicePreserve;
-    QString rootDevicePreserve;
-    QString homeDevicePreserve;
+    QString bootDevice;
+    QString swapDevice;
+    QString rootDevice;
+    QString homeDevice;
     QString espDevice;
 
     int showPage(int curr, int next);
@@ -200,11 +200,11 @@ private:
 
     // if these variables are non-zero then the installer formats the partition
     // if they are negative the installer formats an existing partition
-    qint64 root_size = 0;
-    qint64 home_size = 0;
-    qint64 swap_size = 0;
-    qint64 boot_size = 0;
-    qint64 esp_size = 0;
+    qint64 rootFormatSize = 0;
+    qint64 homeFormatSize = 0;
+    qint64 swapFormatSize = 0;
+    qint64 bootFormatSize = 0;
+    qint64 espFormatSize = 0;
 
     QWidget *nextFocus = NULL;
     BlockDeviceList listBlkDevs, listBlkDevsBackup;

--- a/minstall.h
+++ b/minstall.h
@@ -49,7 +49,7 @@ struct BlockDeviceInfo {
         bool esp : 1;
         bool swap : 1;
     } flags;
-    QString comboFormat() const;
+    QString comboFormat(bool showfs = true) const;
 };
 
 class MInstall : public QDialog, public Ui::MeInstall {

--- a/minstall.h
+++ b/minstall.h
@@ -242,7 +242,7 @@ private:
     // slots
     void startup();
     // helpers
-    bool execute(const QString &cmd, const bool rawexec = false, const QByteArray &input = QByteArray());
+    bool execute(const QString &cmd, const bool rawexec = false, const QByteArray *input = NULL, bool needRead = false);
     QString getCmdOut(const QString &cmd, bool everything = false);
     // private functions
     void updateStatus(const QString &msg, int val = -1);

--- a/minstall.h
+++ b/minstall.h
@@ -42,13 +42,11 @@ struct BlockDeviceInfo {
     QString label;
     QString model;
     qint64 size;
-    struct {
-        bool disk : 1;
-        bool native : 1;
-        bool boot : 1;
-        bool esp : 1;
-        bool swap : 1;
-    } flags;
+    bool isDisk : 1;
+    bool isNative : 1;
+    bool isBoot : 1;
+    bool isESP : 1;
+    bool isSwap : 1;
     QString comboFormat(bool showfs = true) const;
 };
 

--- a/minstall.h
+++ b/minstall.h
@@ -217,8 +217,8 @@ private:
     bool haveSamba = false;
     bool haveSnapshotUserAccounts = false;
     enum OldHomeAction {
-        OldHomeUse, OldHomeSave, OldHomeDelete
-    } oldHomeAction;
+        OldHomeNothing, OldHomeUse, OldHomeSave, OldHomeDelete
+    } oldHomeAction = OldHomeNothing;
 
     // Advanced Encryption Settings page
     int ixPageRefAdvancedFDE = 0;

--- a/minstall.h
+++ b/minstall.h
@@ -98,7 +98,6 @@ public:
     void makeFstab();
     bool processNextPhase();
     void removeItemCombo(QComboBox *cb, const QString *part);
-    void saveConfig();
     void setLocale();
     void setServices();
     void updatePartCombo(QString *prevItem, const QString &part);
@@ -188,6 +187,9 @@ private:
 
     // command line options
     bool pretend, automatic, nocopy, sync;
+    // configuration management
+    enum ConfigAction { ConfigSave, ConfigLoadA, ConfigLoadB };
+    int configStuck = 0;
 
     bool formatSwap = false;
     bool isHomeEncrypted = false;
@@ -262,6 +264,7 @@ private:
     bool installLinux(const int progend);
     bool copyLinux(const int progend);
     void failUI(const QString &msg);
+    int manageConfig(enum ConfigAction mode);
     void stashServices(bool save);
     void stashAdvancedFDE(bool save);
 };

--- a/minstall.h
+++ b/minstall.h
@@ -251,7 +251,6 @@ private:
     QStringList splitDevice(const QString &device) const;
     void buildBlockDevList();
     bool pretendToInstall(int start, int stop, int sleep);
-    void prepareToInstall();
     bool saveHomeBasic();
     bool calculateDefaultPartitions();
     bool calculateChosenPartitions();

--- a/minstall.h
+++ b/minstall.h
@@ -82,7 +82,6 @@ public:
     bool checkDisk();
     bool checkPassword(const QString &pass);
     bool installLoader();
-    bool validateChosenPartitions();
     bool makeLinuxPartition(const QString &dev, const QString &type, bool bad, const QString &label);
     bool makeLuksPartition(const QString &dev, const QByteArray &password);
     bool openLuksPartition(const QString &dev, const QString &fs_name, const QByteArray &password, const QString &options = QString(), const bool failHard = true);
@@ -250,8 +249,8 @@ private:
     void buildBlockDevList();
     bool pretendToInstall(int start, int stop, int sleep);
     bool saveHomeBasic();
+    bool validateChosenPartitions();
     bool calculateDefaultPartitions();
-    bool calculateChosenPartitions();
     bool makePartitions();
     bool formatPartitions();
     bool installLinux(const int progend);

--- a/minstall.h
+++ b/minstall.h
@@ -229,7 +229,7 @@ private:
     int iFDEkeysize;
     int indexFDEhash;
     int indexFDErandom;
-    long iFDEroundtime;
+    int iFDEroundtime;
 
     // slots
     void startup();

--- a/minstall.h
+++ b/minstall.h
@@ -49,7 +49,7 @@ struct BlockDeviceInfo {
         bool esp : 1;
         bool swap : 1;
     } flags;
-    QString comboFormat();
+    QString comboFormat() const;
 };
 
 class MInstall : public QDialog, public Ui::MeInstall {
@@ -107,10 +107,10 @@ public:
     bool INSTALL_FROM_ROOT_DEVICE;
     bool POPULATE_MEDIA_MOUNTPOINTS;
 
+    qlonglong MIN_BOOT_DEVICE_SIZE;
+    qlonglong MIN_ROOT_DEVICE_SIZE;
     QString DEFAULT_HOSTNAME;
-    QString MIN_BOOT_DEVICE_SIZE;
     QString MIN_INSTALL_SIZE;
-    QString MIN_ROOT_DEVICE_SIZE;
     QString PREFERRED_MIN_INSTALL_SIZE;
     QString PROJECTFORUM;
     QString PROJECTNAME;
@@ -257,6 +257,7 @@ private:
     // private functions
     void updateStatus(const QString &msg, int val = -1);
     void updateCursor(const Qt::CursorShape shape = Qt::ArrowCursor);
+    QStringList splitDevice(const QString &device) const;
     void buildBlockDevList();
     bool pretendToInstall(int start, int stop, int sleep);
     void prepareToInstall();

--- a/minstall.h
+++ b/minstall.h
@@ -42,6 +42,7 @@ struct BlockDeviceInfo {
     QString label;
     QString model;
     qint64 size;
+    bool isFuture : 1;
     bool isDisk : 1;
     bool isGPT : 1;
     bool isBoot : 1;
@@ -82,7 +83,7 @@ public:
     bool checkPassword(const QString &pass);
     bool installLoader();
     bool validateChosenPartitions();
-    bool makeDefaultPartitions(bool &formatBoot);
+    bool makeDefaultPartitions();
     bool makeEsp(const QString &drv, int size);
     bool makeLinuxPartition(const QString &dev, const QString &type, bool bad, const QString &label);
     bool makeLuksPartition(const QString &dev, const QByteArray &password);
@@ -119,7 +120,7 @@ public:
     bool REMOVE_NOSPLASH;
 
     // global for now until boot combo box is sorted out
-    QString bootdev;
+    QString bootDevicePreserve;
     QString swapDevicePreserve;
     QString rootDevicePreserve;
     QString homeDevicePreserve;
@@ -199,8 +200,16 @@ private:
     bool uefi = false;
     bool haveSysConfig = false;
 
+    // if these variables are non-zero then the installer formats the partition
+    // if they are negative the installer formats an existing partition
+    qint64 root_size = 0;
+    qint64 home_size = 0;
+    qint64 swap_size = 0;
+    qint64 boot_size = 0;
+    qint64 esp_size = 0;
+
     QWidget *nextFocus = NULL;
-    BlockDeviceList listBlkDevs;
+    BlockDeviceList listBlkDevs, listBlkDevsBackup;
     QString home_mntops = "defaults";
     QString root_mntops = "defaults";
     QStringList listHomes;
@@ -245,8 +254,9 @@ private:
     bool pretendToInstall(int start, int stop, int sleep);
     void prepareToInstall();
     bool saveHomeBasic();
-    bool makeChosenPartitions(QString &rootType, QString &homeType, bool &formatBoot);
-    bool formatPartitions(const QByteArray &encPass, const QString &rootType, const QString &homeType, bool formatBoot);
+    bool calculateFuturePartitions();
+    bool makeChosenPartitions();
+    bool formatPartitions(const QByteArray &encPass);
     bool installLinux(const int progend);
     bool copyLinux(const int progend);
     void failUI(const QString &msg);

--- a/minstall.h
+++ b/minstall.h
@@ -37,8 +37,7 @@ public:
 
 struct BlockDeviceInfo {
     QString name;
-    QString uuid;
-    QString fstype;
+    QString fs;
     QString label;
     QString model;
     qint64 size;

--- a/minstall.h
+++ b/minstall.h
@@ -42,13 +42,14 @@ struct BlockDeviceInfo {
     QString model;
     qint64 size;
     bool isFuture = false;
+    bool isNasty = false;
     bool isDisk = false;
     bool isGPT = false;
     bool isBoot = false;
     bool isESP = false;
     bool isNative = false;
     bool isSwap = false;
-    void addToCombo(QComboBox *combo) const;
+    void addToCombo(QComboBox *combo, bool warnNasty = false) const;
 };
 
 class BlockDeviceList : public QList<BlockDeviceInfo> {
@@ -182,7 +183,7 @@ private:
     int phase = 0;
 
     // command line options
-    bool pretend, automatic, nocopy, sync;
+    bool brave, pretend, automatic, nocopy, sync;
     // configuration management
     QSettings *config = NULL;
     enum ConfigAction { ConfigSave, ConfigLoadA, ConfigLoadB };

--- a/minstall.h
+++ b/minstall.h
@@ -193,7 +193,6 @@ private:
     bool isRootEncrypted = false;
     bool isSwapEncrypted = false;
     bool uefi = false;
-    bool haveSysConfig = false;
 
     // if these variables are non-zero then the installer formats the partition
     // if they are negative the installer formats an existing partition

--- a/minstall.h
+++ b/minstall.h
@@ -94,9 +94,7 @@ public:
     void addItemCombo(QComboBox *cb, const QString *part);
     void buildBootLists();
     void buildServiceList();
-    bool copyLinux();
     void disablehiberanteinitramfs();
-    bool installLinux();
     void makeFstab();
     bool processNextPhase();
     void removeItemCombo(QComboBox *cb, const QString *part);
@@ -207,9 +205,6 @@ private:
     QStringList listHomes;
     SafeCache key;
 
-    // for file copy progress updates
-    int iCopyBarB;
-
     // for the tips display
     int ixTip = 0;
     int ixTipStart = -1;
@@ -226,7 +221,6 @@ private:
     QString prevItemHome;
     QString prevItemSwap;
     QString prevItemBoot;
-    int indexPartInfoDisk = -1;
 
     // info needed for Phase 2 of the process
     QStringList listBootDrives;
@@ -265,6 +259,8 @@ private:
     bool saveHomeBasic();
     bool makeChosenPartitions(QString &rootType, QString &homeType, bool &formatBoot);
     bool formatPartitions(const QByteArray &encPass, const QString &rootType, const QString &homeType, bool formatBoot);
+    bool installLinux(const int progend);
+    bool copyLinux(const int progend);
     void failUI(const QString &msg);
     void stashServices(bool save);
     void stashAdvancedFDE(bool save);

--- a/minstall.h
+++ b/minstall.h
@@ -190,12 +190,9 @@ private:
     int configStuck = 0;
 
     QString auto_mount;
-    bool formatSwap = false;
     bool isHomeEncrypted = false;
     bool isRootEncrypted = false;
     bool isSwapEncrypted = false;
-    bool isRootFormatted = false;
-    bool isHomeFormatted = false;
     bool uefi = false;
     bool haveSysConfig = false;
 

--- a/minstall.h
+++ b/minstall.h
@@ -252,7 +252,8 @@ private:
     bool pretendToInstall(int start, int stop, int sleep);
     void prepareToInstall();
     bool saveHomeBasic();
-    bool calculateFuturePartitions();
+    bool calculateDefaultPartitions();
+    bool calculateChosenPartitions();
     bool makePartitions();
     bool formatPartitions();
     bool installLinux(const int progend);

--- a/minstall.h
+++ b/minstall.h
@@ -104,7 +104,6 @@ public:
     void setLocale();
     void setServices();
     void updatePartCombo(QString *prevItem, const QString &part);
-    void updatePartitionWidgets();
     void writeKeyFile();
 
     bool INSTALL_FROM_ROOT_DEVICE;
@@ -133,7 +132,6 @@ public:
     int showPage(int curr, int next);
     void gotoPage(int next);
     void pageDisplayed(int next);
-    void updateDiskInfo();
     void setupkeyboardbutton();
     bool abort(bool onclose);
     void cleanup(bool endclean = true);
@@ -173,7 +171,6 @@ private slots:
     void on_checkBoxEncryptHome_toggled(bool checked);
     void on_checkBoxEncryptSwap_toggled(bool checked);
 
-    void updatePartInfo();
     void on_rootTypeCombo_activated(QString item = "");
     void on_rootCombo_activated(const QString &arg1 = "");
     void on_homeCombo_activated(const QString &arg1);
@@ -260,6 +257,7 @@ private:
     // private functions
     void updateStatus(const QString &msg, int val = -1);
     void updateCursor(const Qt::CursorShape shape = Qt::ArrowCursor);
+    void updatePartitionWidgets();
     QStringList splitDevice(const QString &device) const;
     void buildBlockDevList();
     bool pretendToInstall(int start, int stop, int sleep);

--- a/minstall.h
+++ b/minstall.h
@@ -38,6 +38,8 @@ public:
 struct BlockDeviceInfo {
     QString name;
     QString uuid;
+    QString fstype;
+    QString label;
     QString model;
     qint64 size;
     struct {
@@ -47,6 +49,7 @@ struct BlockDeviceInfo {
         bool esp : 1;
         bool swap : 1;
     } flags;
+    QString comboFormat();
 };
 
 class MInstall : public QDialog, public Ui::MeInstall {


### PR DESCRIPTION
- The GUI should now appear earlier, with most of the startup code being delayed.
- Added ability to load a configuration file (only /etc/minstall.conf for now).
- Calculate future partitions and use the results to populate the boot device list.
- Eliminated the pause between the drive/partition setup and the boot loader page.
- Optimised the localization page for smaller 800x600 and 640x480 screens.
- New block device list mechanism that reduces the amount of device probes and eliminates the partition-info dependency.
- Added **nasty** flag to mark some devices as unsuitable for MBR/PBR installation.
- The vintage Apple HFS+ check now uses the **nasty** flag.
- Added check for Windows LDM devices, uses the **nasty** flag.
- Added _--brave_ option to bypass the **nasty** blocks. A warning icon is shown next to **nasty** partitions when using the _--brave_ option.