### PR TITLE
Check SMART status of all target drives.

### DIFF
--- a/blockdev.cpp
+++ b/blockdev.cpp
@@ -95,10 +95,10 @@ void BlockDeviceList::build(MProcess &proc)
 
         BlockDeviceInfo bdinfo;
         bdinfo.isFuture = false;
-        bdinfo.isDisk = (bdsegs.at(0) == "disk");
+        bdinfo.isDrive = (bdsegs.at(0) == "disk");
         bdinfo.name = bdsegs.at(1);
 
-        if (bdinfo.isDisk) {
+        if (bdinfo.isDrive) {
             driveIndex = count();
             const QString cmd("blkid /dev/%1 | grep -q PTTYPE=\\\"gpt\\\"");
             gpt = proc.exec(cmd.arg(bdinfo.name), false);
@@ -112,7 +112,7 @@ void BlockDeviceList::build(MProcess &proc)
             operator[](driveIndex).isBoot = true;
             for (int ixi = driveIndex + 1; ixi < count(); ++ixi) {
                 BlockDeviceInfo &bdi = operator[](ixi);
-                if (bdi.isDisk) break;
+                if (bdi.isDrive) break;
                 bdi.isBoot = true;
             }
         }
@@ -128,7 +128,7 @@ void BlockDeviceList::build(MProcess &proc)
             bdinfo.isESP = bdinfo.isSwap = bdinfo.isNative = false;
         }
 
-        if (!bdinfo.isDisk && !bdinfo.isESP) {
+        if (!bdinfo.isDrive && !bdinfo.isESP) {
             // check the backup ESP detection list
             bdinfo.isESP = backup_list.contains(bdinfo.name);
         }
@@ -153,7 +153,7 @@ void BlockDeviceList::build(MProcess &proc)
     qDebug() << "Name Size Model FS | isDisk isGPT isBoot isESP isNative isSwap";
     for (const BlockDeviceInfo &bdi : *this) {
         qDebug() << bdi.name << bdi.size << bdi.model << bdi.fs << "|"
-                 << bdi.isDisk << bdi.isGPT << bdi.isBoot << bdi.isESP
+                 << bdi.isDrive << bdi.isGPT << bdi.isBoot << bdi.isESP
                  << bdi.isNative << bdi.isSwap;
     }
 }

--- a/blockdev.h
+++ b/blockdev.h
@@ -30,7 +30,7 @@ struct BlockDeviceInfo
     qint64 size;
     bool isFuture = false;
     bool isNasty = false;
-    bool isDisk = false;
+    bool isDrive = false;
     bool isGPT = false;
     bool isBoot = false;
     bool isESP = false;

--- a/minstall.h
+++ b/minstall.h
@@ -49,7 +49,7 @@ public:
 
     bool isInsideVB();
 
-    bool checkDisk();
+    bool checkTargetDrivesOK();
     bool installLoader();
     bool makeLinuxPartition(const QString &dev, const QString &type, bool bad, const QString &label);
     bool makeLuksPartition(const QString &dev, const QByteArray &password);


### PR DESCRIPTION
Much of this code has been sitting in my local stash, uncommitted, for about a month and getting stale, so better it goes in now.
It does change some strings in the error message, but I think it's a small price to pay since the previous code only did the SMART detection on one of the drives and doesn't even work properly when you use the custom partition setup.

Example: you select **sdb1** for root and **sdc1** for home in the custom partition setup, the SMART detection will likely check **sda** because that's what's in diskCombo, even though this combo is not used in the custom setup.

This new fix changes that and so the SMART test will be performed on both **sdb** and **sdc** to ensure both drives are fit for installation.