### PR TITLE
Debugging enhancements.

### DIFF
--- a/minstall.cpp
+++ b/minstall.cpp
@@ -1558,7 +1558,7 @@ bool MInstall::copyLinux(const int progend)
         const int progdiv = (progspace != 0) ? (sourceInodes / progspace) : 0;
         while (proc.state() != QProcess::NotRunning) {
             eloop.exec();
-            proc.readAll();
+            proc.readAllStandardOutput();
             if(statvfs("/mnt/antiX", &svfs) == 0 && progdiv != 0) {
                 int i = (svfs.f_files - svfs.f_ffree - targetInodes) / progdiv;
                 if (i > progspace) i = progspace;

--- a/mprocess.cpp
+++ b/mprocess.cpp
@@ -29,7 +29,8 @@ MProcess::MProcess(QObject *parent)
 bool MProcess::exec(const QString &cmd, const bool rawexec, const QByteArray *input, bool needRead)
 {
     if (halting) return false;
-    qDebug() << cmd;
+    ++execount;
+    qDebug().nospace() << "Exec #" << execount << ": " << cmd;
     QEventLoop eloop;
     connect(this, static_cast<void (QProcess::*)(int)>(&QProcess::finished), &eloop, &QEventLoop::quit);
     if (rawexec) start(cmd);
@@ -45,19 +46,19 @@ bool MProcess::exec(const QString &cmd, const bool rawexec, const QByteArray *in
     if (debugUnusedOutput) {
         if (!needRead) {
             const QByteArray &StdOut = readAllStandardOutput();
-            if (!StdOut.isEmpty()) qDebug() << "stdout:" << StdOut;
+            if (!StdOut.isEmpty()) qDebug().nospace() << "SOut #" << execount << ": " << StdOut;
         }
         const QByteArray &StdErr = readAllStandardError();
-        if (!StdErr.isEmpty()) qDebug() << "stderr:" << StdErr;
+        if (!StdErr.isEmpty()) qDebug().nospace() << "SErr #" << execount << ": " << StdErr;
     }
-    qDebug() << "Exit:" << exitCode() << exitStatus();
+    qDebug().nospace() << "Exit #" << execount << ": " << exitCode() << " " << exitStatus();
     return (exitStatus() == QProcess::NormalExit && exitCode() == 0);
 }
 
 QString MProcess::execOut(const QString &cmd, bool everything)
 {
     exec(cmd, false, nullptr, true);
-    QString strout(readAll().trimmed());
+    QString strout(readAllStandardOutput().trimmed());
     if (everything) return strout;
     return strout.section("\n", 0, 0);
 }
@@ -65,7 +66,7 @@ QString MProcess::execOut(const QString &cmd, bool everything)
 QStringList MProcess::execOutLines(const QString &cmd)
 {
     exec(cmd, false, nullptr, true);
-    return QString(readAll().trimmed()).split('\n');
+    return QString(readAllStandardOutput().trimmed()).split('\n');
 }
 
 void MProcess::halt()

--- a/mprocess.h
+++ b/mprocess.h
@@ -23,6 +23,7 @@
 
 class MProcess : public QProcess
 {
+    int execount = 0;
     bool halting = false;
     bool debugUnusedOutput = true;
 public:

--- a/mprocess.h
+++ b/mprocess.h
@@ -24,6 +24,7 @@
 class MProcess : public QProcess
 {
     bool halting = false;
+    bool debugUnusedOutput = true;
 public:
     MProcess(QObject *parent = Q_NULLPTR);
     bool exec(const QString &cmd, const bool rawexec = false, const QByteArray *input = nullptr, bool needRead = false);


### PR DESCRIPTION
If the installer doesn't use the command's standard output for anything, print it to the debug. Also print standard error.

Also added a command execution counter, and improved the format so it is easier to distinguish command executions from other debugging messages.