### PR TITLE
fix UUID for resume and remove leftover resume paramter from grub and cmdline

### DIFF
--- a/bootman.cpp
+++ b/bootman.cpp
@@ -189,6 +189,14 @@ void BootMan::install(const QStringList &cmdextra)
         proc.shell("/live/bin/non-live-cmdline", nullptr, true); // Get non-live boot codes
         QStringList finalcmdline = proc.readOut().split(" ");
         finalcmdline.append(grubDefault.split(" "));
+
+        // remove any leftover resume parameter
+        const QRegularExpression re("^(resume=|resume_offset=)", QRegularExpression::CaseInsensitiveOption);
+        const auto toRemove = finalcmdline.filter(re);
+        for(const auto &item : toRemove) {
+            finalcmdline.removeAll(item);
+        }
+
         finalcmdline.append(cmdextra);
         qDebug() << "intermediate" << finalcmdline;
 
@@ -215,6 +223,7 @@ void BootMan::install(const QStringList &cmdextra)
 
         //remove nosplash boot code if configured in installer.conf
         if (removeNoSplash) finalcmdline.removeAll("nosplash");
+
         //remove in null or empty strings that might have crept in
         finalcmdline.removeAll({});
         qDebug() << "Add cmdline options to Grub" << finalcmdline;

--- a/swapman.cpp
+++ b/swapman.cpp
@@ -109,7 +109,8 @@ void SwapMan::install(QStringList &cmdboot_out)
     file.close();
     // Hibernation.
     if (gui.checkHibernation->isChecked()) {
-        cmdboot_out.append("resume=UUID=" + device->assocUUID());
+        proc.shell("blkid -s UUID -o value $(df -P " + instpath + " | awk 'END{print $1}')", nullptr, true);
+        cmdboot_out.append("resume=UUID=" + proc.readAll().trimmed());
         if (btrfs) {
             proc.exec("btrfs", {"inspect-internal", "map-swapfile", "-r", instpath}, nullptr, true);
         } else {


### PR DESCRIPTION
* Fix: Use UUID of the opened luks-partition for the resume parameter
* Fix: Remove leftover resume parameter from grub default config and kernel commandline
